### PR TITLE
updating aptly to start api service, also use nightly build for testing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,7 @@ config.vm.provision :shell, path: "update_puppet.sh"
     end
     buildRepoServer.vm.network "forwarded_port", guest: 80, host: 8081
     buildRepoServer.vm.network "forwarded_port", guest: 8080, host: 8080
+    buildRepoServer.vm.network "forwarded_port", guest: 8082, host: 8082
     buildRepoServer.vm.provision "shell", path: "publish_repos.sh"
   end
 

--- a/puppet/modules/aptly/files/etc/init/aptly-api.conf
+++ b/puppet/modules/aptly/files/etc/init/aptly-api.conf
@@ -1,0 +1,13 @@
+description     "Stat HTTP server with aptly REST API"
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+umask 022
+chdir /
+setuid root
+setgid root
+console log # log stdout/stderr to /var/log/upstart/
+
+
+exec /usr/bin/aptly api serve -listen=:8082

--- a/puppet/modules/aptly/manifests/configure.pp
+++ b/puppet/modules/aptly/manifests/configure.pp
@@ -1,6 +1,8 @@
 #Configure directory and nginx
 class aptly::configure {
 
+  include aptly::service
+
   file { "/vagrant_data/.aptly":
     ensure => directory,
     owner  => www-data,
@@ -13,6 +15,14 @@ class aptly::configure {
     owner   => www-data,
     group   => www-data,
     require => File["/vagrant_data/.aptly"],
+  }
+
+  file { "/etc/init/aptly-api.conf":
+    ensure => present,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/aptly/etc/init/aptly-api.conf',
   }
 
   aptly::repo{ 'stable-repo': }

--- a/puppet/modules/aptly/manifests/init.pp
+++ b/puppet/modules/aptly/manifests/init.pp
@@ -55,7 +55,7 @@ class aptly (
   if $repo {
     apt::source { 'aptly':
       location    => 'http://repo.aptly.info',
-      release     => 'squeeze',
+      release     => 'nightly',
       repos       => 'main',
       key_server  => $key_server,
       key         => '2A194991',

--- a/puppet/modules/aptly/manifests/service.pp
+++ b/puppet/modules/aptly/manifests/service.pp
@@ -1,0 +1,8 @@
+#Aptly API service
+class aptly::service {
+
+  service { 'aptly-api':
+      ensure  => running,
+      require => File['/etc/init/aptly-api.conf'],
+  }
+}


### PR DESCRIPTION
1. Use Aptly nightly build repo since we want to test latest Aptly changes
2. Startup Aptly API service on reposerver VM listening on port 8082
3. Update VagrantFile to forward port 8082 to 8082 so we can talk to API